### PR TITLE
wrap setting array length in try catch

### DIFF
--- a/src/9.negotiation.js
+++ b/src/9.negotiation.js
@@ -607,8 +607,13 @@ export function /*9.2.8 */SupportedLocales (availableLocales, requestedLocales, 
             writable: false, configurable: false, value: subset[P]
         });
     }
-    // "Freeze" the array so no new elements can be added
-    defineProperty(subset, 'length', { writable: false });
+    
+    // Wrap in try catch for older browsers that don't support setting length of
+    // array such as FF 22 and below.
+    try {
+        // "Freeze" the array so no new elements can be added
+        defineProperty(subset, 'length', { writable: false });
+    } catch (e) {}
 
     // 5. Return subset
     return subset;


### PR DESCRIPTION
Older browsers, such as Firefox 22 and below, throw `new InternalError("defining the length property on an array is not currently supported")` when trying to set the length with `defineProperty` so a try catch will allow for those that do support it to use it, while those that don't fail due to the error.